### PR TITLE
test to show that mockery does not work across processes

### DIFF
--- a/test/mockery/multiprocess_test.exs
+++ b/test/mockery/multiprocess_test.exs
@@ -1,0 +1,30 @@
+defmodule Mockery.MultiprocessTest do
+  use ExUnit.Case, async: true
+  import Mockery
+
+  defmodule A do
+    def run do
+      "real"
+    end
+  end
+
+  defmodule B do
+    import Mockery.Macro
+    def run do
+      mockable(A).run
+    end
+  end
+
+  test "same process mocking works" do
+    mock(A, [run: 0], "mock")
+    assert B.run == "mock"
+  end
+
+  test "multiprocess mocking does not work" do
+    mock(A, [run: 0], "mock")
+
+    spawn fn ->
+      assert B.run == "real"
+    end
+  end
+end

--- a/test/mockery/multiprocess_test.exs
+++ b/test/mockery/multiprocess_test.exs
@@ -10,6 +10,7 @@ defmodule Mockery.MultiprocessTest do
 
   defmodule B do
     import Mockery.Macro
+
     def run do
       mockable(A).run
     end
@@ -17,14 +18,14 @@ defmodule Mockery.MultiprocessTest do
 
   test "same process mocking works" do
     mock(A, [run: 0], "mock")
-    assert B.run == "mock"
+    assert B.run() == "mock"
   end
 
   test "multiprocess mocking does not work" do
     mock(A, [run: 0], "mock")
 
-    spawn fn ->
-      assert B.run == "real"
-    end
+    spawn(fn ->
+      assert B.run() == "real"
+    end)
   end
 end


### PR DESCRIPTION
problem: 
- there is not documentation that explains why mockery is not keeping mocks intact across multiple erlang processes


solution: 
- we start with a test to make this behaviour explicit


In ideal world it would magically work, but due to the decision to use Process dictionaries it is probably out of scope of `mockery` to cover this. At least we should document it, to prevent confusion. 