### PR TITLE
 Split enable_history/1 to enable_history/0 and disable_history/0

### DIFF
--- a/lib/mockery.ex
+++ b/lib/mockery.ex
@@ -8,7 +8,7 @@ defmodule Mockery do
     quote do
       import Mockery
       import Mockery.Assertions
-      import Mockery.History, only: [enable_history: 0, enable_history: 1]
+      import Mockery.History, only: [enable_history: 0, disable_history: 0]
     end
   end
 

--- a/lib/mockery.ex
+++ b/lib/mockery.ex
@@ -8,7 +8,7 @@ defmodule Mockery do
     quote do
       import Mockery
       import Mockery.Assertions
-      import Mockery.History, only: [enable_history: 0, disable_history: 0]
+      import Mockery.History, only: [enable_history: 0, enable_history: 1, disable_history: 0]
     end
   end
 

--- a/lib/mockery/history.ex
+++ b/lib/mockery/history.ex
@@ -49,8 +49,8 @@ defmodule Mockery.History do
       end
 
   """
-  @spec enable_history() :: :ok
-  def enable_history() do
+  @spec enable_history :: :ok
+  def enable_history do
     Process.put(__MODULE__, true)
 
     :ok
@@ -69,8 +69,8 @@ defmodule Mockery.History do
       end
 
   """
-  @spec disable_history() :: :ok
-  def disable_history() do
+  @spec disable_history :: :ok
+  def disable_history do
     Process.put(__MODULE__, false)
 
     :ok

--- a/lib/mockery/history.ex
+++ b/lib/mockery/history.ex
@@ -17,17 +17,6 @@ defmodule Mockery.History do
   import IO.ANSI
   alias Mockery.Utils
 
-  @doc """
-  Enables/disables history in scope of single test process
-      use Mockery
-      test "example" do
-        #...
-        enable_history()
-        assert_called Foo, :bar, [_, :a]
-        enable_history(false)
-        assert_called Foo, :bar, [_, :b]
-      end
-  """
   @deprecated "Use enable_history/0 or disable_history/0 instead"
   @spec enable_history(enabled :: boolean) :: :ok
   def enable_history(enabled) do

--- a/lib/mockery/history.ex
+++ b/lib/mockery/history.ex
@@ -9,7 +9,8 @@ defmodule Mockery.History do
 
   Or for single test process
 
-      Mockery.History.enable_history(true)
+      Mockery.History.enable_history()
+      Mockery.History.disable_history()
 
   Process config has higher priority than global config
   """
@@ -17,7 +18,7 @@ defmodule Mockery.History do
   alias Mockery.Utils
 
   @doc """
-  Enables/disables history in scope of single test process
+  Enables history in scope of single test process
 
       use Mockery
 
@@ -26,15 +27,32 @@ defmodule Mockery.History do
 
         enable_history()
         assert_called Foo, :bar, [_, :a]
-
-        enable_history(false)
-        assert_called Foo, :bar, [_, :b]
       end
 
   """
-  @spec enable_history(enabled :: boolean) :: :ok
-  def enable_history(enabled \\ true) do
-    Process.put(__MODULE__, enabled)
+  @spec enable_history() :: :ok
+  def enable_history() do
+    Process.put(__MODULE__, true)
+
+    :ok
+  end
+
+  @doc """
+  Disables history in scope of single test process
+
+      use Mockery
+
+      test "example" do
+        #...
+
+        disable_history()
+        assert_called Foo, :bar, [_, :a]
+      end
+
+  """
+  @spec disable_history() :: :ok
+  def disable_history() do
+    Process.put(__MODULE__, false)
 
     :ok
   end

--- a/lib/mockery/history.ex
+++ b/lib/mockery/history.ex
@@ -18,6 +18,25 @@ defmodule Mockery.History do
   alias Mockery.Utils
 
   @doc """
+  Enables/disables history in scope of single test process
+      use Mockery
+      test "example" do
+        #...
+        enable_history()
+        assert_called Foo, :bar, [_, :a]
+        enable_history(false)
+        assert_called Foo, :bar, [_, :b]
+      end
+  """
+  @deprecated "Use enable_history/0 or disable_history/0 instead"
+  @spec enable_history(enabled :: boolean) :: :ok
+  def enable_history(enabled) do
+    Process.put(__MODULE__, enabled)
+
+    :ok
+  end
+
+  @doc """
   Enables history in scope of single test process
 
       use Mockery

--- a/test/mockery/utils_test.exs
+++ b/test/mockery/utils_test.exs
@@ -26,7 +26,7 @@ defmodule Mockery.UtilsTest do
 
   test "history_enabled?/0 global config ignored when process config present" do
     mock(Application, :get_env, true)
-    enable_history(false)
+    disable_history()
 
     refute Utils.history_enabled?()
     assert_called(Application, :get_env, [:mockery, :history, _], 1)


### PR DESCRIPTION
Switching off recording history with function called `enable_history` is counterintuitive. So I think splitting `enable_history/1` to `enable_history/0` and `disable_history/0` is a good idea.